### PR TITLE
Drop php 5.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ php:
 env:
   - M2_VERSION=2.1.9
   - M2_VERSION=2.0.16
-matrix:
-  include:
-    - php: 5.5
-      env: M2_VERSION=2.0.16
 cache:
   directories:
     - $HOME/.composer/cache

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "AGPL-3.0+"
     ],
     "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0"
+        "php": "~5.6.0|~7.0.0|~7.1.0"
     },
     "autoload": {
         "files": ["registration.php"],


### PR DESCRIPTION
Php 5.5 is already not supporting. http://php.net/eol.php

There is no sense to support it