### PR TITLE
Update composer.json to include PHP 7.2 for Magento 2.3 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "AGPL-3.0+"
     ],
     "require": {
-        "php": "~7.0.0|~7.1.0",
+        "php": "~7.0.0|~7.1.0|~7.2.0",
         "magento/framework": "~101.0",
         "magento/module-catalog": "~102.0",
         "magento/module-catalog-search": "~100.0",


### PR DESCRIPTION
Upgrading while ignoring the prerequisite for PHP 7.1 or 7.0 finished successfully.
The extension seems to be working fine.