### PR TITLE
Update Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,21 @@
 language: php
 php:
-  - 7.2
-  - 7.1
+  - 7.4
+  - 7.3
 env:
-  - M2_VERSION=2.3.2
-  - M2_VERSION=2.3.1
-  - M2_VERSION=2.3.0
-matrix:
+  - M2_VERSION=2.4.2
+  - M2_VERSION=2.4.1
+  - M2_VERSION=2.4.0
+jobs:
   include:
-    - php: 7.1
-      env: M2_VERSION=2.2.9
-    - php: 7.0
-      env: M2_VERSION=2.2.9
+    - php: 7.3
+      env: M2_VERSION=2.3.6-p1
+    - php: 7.3
+      env: M2_VERSION=2.3.5
+    - php: 7.3
+      env: M2_VERSION=2.3.4
+    - php: 7.3
+      env: M2_VERSION=2.3.3
 cache:
   directories:
     - $HOME/.composer/cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ jobs:
       env: M2_VERSION=2.3.6-p1
     - php: 7.3
       env: M2_VERSION=2.3.5
-    - php: 7.3
-      env: M2_VERSION=2.3.4
-    - php: 7.3
-      env: M2_VERSION=2.3.3
 cache:
   directories:
     - $HOME/.composer/cache

--- a/Test/Unit/CustomerData/Checkout/CartPluginTest.php
+++ b/Test/Unit/CustomerData/Checkout/CartPluginTest.php
@@ -77,7 +77,7 @@ class CartPluginTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $className = \Chessio\Matomo\CustomerData\Checkout\CartPlugin::class;
         $objectManager = new ObjectManager($this);

--- a/Test/Unit/CustomerData/Customer/CustomerPluginTest.php
+++ b/Test/Unit/CustomerData/Customer/CustomerPluginTest.php
@@ -77,7 +77,7 @@ class CustomerPluginTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $className = \Chessio\Matomo\CustomerData\Customer\CustomerPlugin::class;
         $objectManager = new ObjectManager($this);

--- a/Test/Unit/Helper/DataTest.php
+++ b/Test/Unit/Helper/DataTest.php
@@ -57,7 +57,7 @@ class DataTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $className = \Chessio\Matomo\Helper\Data::class;
         $objectManager = new ObjectManager($this);

--- a/Test/Unit/Helper/TrackerTest.php
+++ b/Test/Unit/Helper/TrackerTest.php
@@ -49,7 +49,7 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $objectManager = new ObjectManager($this);
 

--- a/Test/Unit/Model/TrackerTest.php
+++ b/Test/Unit/Model/TrackerTest.php
@@ -50,7 +50,7 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $className = \Chessio\Matomo\Model\Tracker::class;
         $objectManager = new ObjectManager($this);

--- a/Test/Unit/Observer/BeforeTrackPageViewObserverTest.php
+++ b/Test/Unit/Observer/BeforeTrackPageViewObserverTest.php
@@ -70,7 +70,7 @@ class BeforeTrackPageViewObserverTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $className = \Chessio\Matomo\Observer\BeforeTrackPageViewObserver::class;
         $objectManager = new ObjectManager($this);

--- a/Test/Unit/Observer/CartViewObserverTest.php
+++ b/Test/Unit/Observer/CartViewObserverTest.php
@@ -84,7 +84,7 @@ class CartViewObserverTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $className = \Chessio\Matomo\Observer\CartViewObserver::class;
         $objectManager = new ObjectManager($this);

--- a/Test/Unit/Observer/CategoryViewObserverTest.php
+++ b/Test/Unit/Observer/CategoryViewObserverTest.php
@@ -77,7 +77,7 @@ class CategoryViewObserverTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $className = \Chessio\Matomo\Observer\CategoryViewObserver::class;
         $objectManager = new ObjectManager($this);

--- a/Test/Unit/Observer/CheckoutSuccessObserverTest.php
+++ b/Test/Unit/Observer/CheckoutSuccessObserverTest.php
@@ -91,7 +91,7 @@ class CheckoutSuccessObserverTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $objectMgr = new ObjectManager($this);
 

--- a/Test/Unit/Observer/ProductViewObserverTest.php
+++ b/Test/Unit/Observer/ProductViewObserverTest.php
@@ -84,7 +84,7 @@ class ProductViewObserverTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $className = \Chessio\Matomo\Observer\ProductViewObserver::class;
         $objectManager = new ObjectManager($this);

--- a/Test/Unit/Observer/SearchResultObserverTest.php
+++ b/Test/Unit/Observer/SearchResultObserverTest.php
@@ -91,7 +91,7 @@ class SearchResultObserverTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $className = \Chessio\Matomo\Observer\SearchResultObserver::class;
         $objectManager = new ObjectManager($this);

--- a/dev/ci/build.sh
+++ b/dev/ci/build.sh
@@ -20,8 +20,7 @@ for envkey in \
   MODULE_SRC_DIR \
   M2_VERSION \
   M2_REPO_USERNAME \
-  M2_REPO_PASSWORD \
-  GITHUB_OAUTH_TOKEN
+  M2_REPO_PASSWORD
 do
   if [ -z "$(eval echo \$$envkey)" ]
   then
@@ -44,8 +43,6 @@ fi
 # Set composer authentication params
 "$COMPOSER_BIN" config --global \
   "http-basic.repo.magento.com" "$M2_REPO_USERNAME" "$M2_REPO_PASSWORD"
-"$COMPOSER_BIN" config --global \
-  "github-oauth.github.com" "$GITHUB_OAUTH_TOKEN"
 
 set -x
 
@@ -56,12 +53,6 @@ set -x
   --repository-url=https://repo.magento.com/ \
   magento/project-community-edition \
   "$BUILD_DIR" "$M2_VERSION"
-
-# Downgrade doctrine/instantiator for PHP < 7.1 support
-"$COMPOSER_BIN" require \
-  --working-dir="$BUILD_DIR" \
-  --ignore-platform-reqs \
-  doctrine/instantiator:v1.0.5
 
 # Copy module into Magento
 mkdir -p "$(dirname "$MODULE_DST_DIR")"


### PR DESCRIPTION
- Remove unnecessary environment variable `GITHUB_OAUTH_TOKEN` (former API limit has been [removed](https://github.com/composer/composer/issues/4884#issuecomment-195229989) in 2016)
- Remove manual `doctrine/instantiator` downgrade
- We support only PHP 7.3 and 7.4 (former versions reached EOL)
- We support only Magento 2 versions starting from v2.3.5
- Add declaration of return value in `setUp(): void` in `*Test.php` as required by PHPUnit

Pull request resolves #52.