### PR TITLE
Fix issue with system config path

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -141,7 +141,7 @@
                            showInWebsite="1"
                            showInStore="1">
                         <label>PHP Script Path</label>
-                        <config_path>matomo/tracking/php_script_path</config_path>
+                        <config_path>piwik/tracking/php_script_path</config_path>
                         <comment>Path to the Matomo tracker PHP script. Usually &quot;matomo.php&quot;.</comment>
                         <frontend_class>required-entry</frontend_class>
                     </field>
@@ -153,7 +153,7 @@
                            showInWebsite="1"
                            showInStore="1">
                         <label>Javascript Path</label>
-                        <config_path>matomo/tracking/js_script_path</config_path>
+                        <config_path>piwik/tracking/js_script_path</config_path>
                         <comment>Path to the Matomo tracker Javascript. Usually &quot;matomo.js&quot;.</comment>
                         <frontend_class>required-entry</frontend_class>
                     </field>
@@ -165,7 +165,7 @@
                            showInWebsite="1"
                            showInStore="1">
                         <label>CDN Hostname</label>
-                        <config_path>matomo/tracking/cdn_hostname</config_path>
+                        <config_path>piwik/tracking/cdn_hostname</config_path>
                         <comment>Hostname for serving the Matomo tracker Javascript. May be left empty in which case the regular hostname will be used.</comment>
                     </field>
                 </group>


### PR DESCRIPTION
Currently in the system.xml **PHP Script Path**, **Javascript Path** and **CDN Hostname** fields have defined `<config_path>matomo/tracking/*</config_path>`
But in the **Helper** paths are defined as `piwik/tracking/*`.
As result, we can't change these fields from the admin panel.

This PR is to fix the following issue.